### PR TITLE
Add Ubuntu to the Debian family of supported OSs and fix some broken variable references

### DIFF
--- a/manifests/pamd.pp
+++ b/manifests/pamd.pp
@@ -275,8 +275,7 @@ class pam::pamd (
   }
 
   case $::operatingsystem {
-
-    /(?i:Debian)/: {
+    /(?i:Debian|Ubuntu)/: { 
       include pam::pamd::debian
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,8 +3,7 @@
 class pam::params {
 
   case $::operatingsystem {
-
-    /(?i:Debian)/: {
+    /(?i:Debian|Ubuntu)/: {
       $packages    = [ 'libpam-ldap' ]
       $prefix_pamd = '/etc/pam.d'
       $owner       = 'root'

--- a/templates/pam.d/common-session-noninteractive.erb
+++ b/templates/pam.d/common-session-noninteractive.erb
@@ -4,7 +4,7 @@
 ###############################################################################
 
 <% if scope.lookupvar('pam::pamd::pam_mkhomedir') == true then -%>
-session	<%= scope.lookupvar('pam::pamd::pam_mkhomedir_session_set') %>
+session	<%= scope.lookupvar('pam::params::pam_mkhomedir_session') %>
 <% end -%>
 
 session	[default=1]	pam_permit.so
@@ -12,5 +12,5 @@ session	requisite	pam_deny.so
 session	required	pam_permit.so
 session	required	pam_unix.so 
 <% if scope.lookupvar('pam::pamd::pam_ldap') == true then -%>
-session	<%= scope.lookupvar('pam::pamd::pam_ldap_session_set') %>
+session	<%= scope.lookupvar('pam::params::pam_ldap_session') %>
 <% end -%>

--- a/templates/pam.d/common-session.erb
+++ b/templates/pam.d/common-session.erb
@@ -4,7 +4,7 @@
 ###############################################################################
 
 <% if scope.lookupvar('pam::pamd::pam_mkhomedir') == true then -%>
-session	<%= scope.lookupvar('pam::pamd::pam_mkhomedir_session_set') %>
+session	<%= scope.lookupvar('pam::params::pam_mkhomedir_session') %>
 <% end -%>
 
 session	[default=1]	pam_permit.so
@@ -13,5 +13,5 @@ session	required	pam_permit.so
 session	required	pam_unix.so 
 <% if scope.lookupvar('pam::pamd::pam_ldap') == true then -%>
 #session	optional	pam_ldap.so 
-session	<%= scope.lookupvar('pam::pamd::pam_ldap_session_set') %>
+session	<%= scope.lookupvar('pam::params::pam_ldap_session') %>
 <% end -%>


### PR DESCRIPTION
See summary, some references to variables in pam::pamd were broken because they were actually in pam::params. Also added Ubuntu to the support OS family case statement.
