### PR TITLE
Add links => follow for authconfig file

### DIFF
--- a/manifests/pamd/redhat.pp
+++ b/manifests/pamd/redhat.pp
@@ -6,6 +6,7 @@ class pam::pamd::redhat {
 
   File {
     ensure => present,
+    links  => follow,
     owner  => 'root',
     group  => 'root',
     mode   => '0644'


### PR DESCRIPTION
In RHEL5 the authconfig file is a symlink; we need to follow links with 'links => follow' if it finds them.
