### PR TITLE
Add sssd and pam_unix customization

### DIFF
--- a/manifests/pamd.pp
+++ b/manifests/pamd.pp
@@ -318,8 +318,8 @@ class pam::pamd (
     }
 
     service { 'sssd':
-      ensure => running,
-      enabled => true,
+      ensure  => running,
+      enable  => true,
       require => Package['sssd'],
     }
 

--- a/manifests/pamd.pp
+++ b/manifests/pamd.pp
@@ -384,6 +384,12 @@ class pam::pamd (
 
   if($pam_mkhomedir) {
 
+    if($pam::params::pam_mkhomedir_package) {
+      package { $pam::params::pam_mkhomedir_package:
+        ensure => present
+      }
+    }
+
     case $pam_mkhomedir_session {
       false:   { $pam_mkhomedir_session_set = $pam::params::pam_mkhomedir_session }
       default: { $pam_mkhomedir_session_set = $pam_mkhomedir_session }

--- a/manifests/pamd.pp
+++ b/manifests/pamd.pp
@@ -212,6 +212,7 @@ class pam::pamd (
   $pam_sss_auth          = false,
   $pam_sss_password      = false,
   $pam_sss_session       = false,
+  $sssd_conf             = false,
 
   $pam_tally             = false,
   $pam_tally_account     = false,
@@ -317,10 +318,16 @@ class pam::pamd (
       ensure => present,
     }
 
+    file { '/etc/sssd/sssd.conf':
+      ensure => file,
+      source => $sssd_conf,
+      require => Package['sssd'],
+    }
+
     service { 'sssd':
       ensure  => running,
       enable  => true,
-      require => Package['sssd'],
+      require => File['/etc/sssd/sssd.conf'],
     }
 
     case $pam_sss_account {

--- a/manifests/pamd.pp
+++ b/manifests/pamd.pp
@@ -6,6 +6,30 @@
 #
 # === Parameters
 #
+#  [pam_unix_account]
+#  When specified, it allows for customization
+#  of pam_unix.so in account type
+#  *Requires* pam_unix => true
+#  *Optional* defaults to 'required      pam_unix.so broken_shadow'
+#
+#  [pam_unix_auth]
+#  When specified, it allows for customization
+#  of pam_unix.so in auth type
+#  *Requires* pam_unix => true
+#  *Optional* defaults to 'sufficient    pam_unix.so nullok try_first_pass'
+#
+#  [pam_unix_password]
+#  When specified, it allows for customization
+#  of pam_unix.so in password type
+#  *Requires* pam_unix => true
+#  *Optional* defaults to 'sufficient    pam_unix.so md5 shadow nullok try_first_pass use_authtok'
+#
+#  [pam_unix_session]
+#  When specified, it allows for customization
+#  of pam_unix.so in session type
+#  *Requires* pam_unix => true
+#  *Optional* defaults to 'required      pam_unix.so'
+#
 #  [pam_ldap]
 #  If enabled sets up the usage of pam_ldap.so
 #  *Conflicts* pam_ldapd
@@ -138,6 +162,11 @@
 #
 #
 class pam::pamd (
+  $pam_unix_account      = false,
+  $pam_unix_auth         = false,
+  $pam_unix_password     = false,
+  $pam_unix_session      = false,
+
   $pam_ldap              = false,
   $pam_ldap_account      = false,
   $pam_ldap_auth         = false,
@@ -170,6 +199,26 @@ class pam::pamd (
 
   if($enable_motd) {
     motd::register { 'pam::pamd': }
+  }
+
+  case $pam_unix_account {
+    false:   { $pam_unix_account_set = $pam::params::pam_unix_account }
+    default: { $pam_unix_account_set = $pam_unix_account }
+  }
+
+  case $pam_unix_auth {
+    false:   { $pam_unix_auth_set = $pam::params::pam_unix_auth }
+    default: { $pam_unix_auth_set = $pam_unix_auth }
+  }
+
+  case $pam_unix_password {
+    false:   { $pam_unix_password_set = $pam::params::pam_unix_password }
+    default: { $pam_unix_password_set = $pam_unix_password }
+  }
+
+  case $pam_unix_session {
+    false:   { $pam_unix_session_set = $pam::params::pam_unix_session }
+    default: { $pam_unix_session_set = $pam_unix_session }
   }
 
   if($pam_ldap) {

--- a/manifests/pamd.pp
+++ b/manifests/pamd.pp
@@ -81,6 +81,34 @@
 #  UNTESTED
 #  *Optional* defaults to false
 #
+#  [pam_sss]
+#  If enabled sets up the usage of pam_sss.so
+#  *Optional* defaults to false
+#
+#  [pam_sss_account]
+#  When specified it allows for customization
+#  of pam_sss.so in account type
+#  *Requires* pam_sss => true
+#  *Optional* defaults to '[default=bad success=ok user_unknown=ignore] pam_sss.so'
+#
+#  [pam_sss_auth]
+#  When specified it allows for customization
+#  of pam_sss.so in auth type
+#  *Requires* pam_sss => true
+#  *Optional* defaults to 'sufficient    pam_sss.so use_first_pass'
+#
+#  [pam_sss_password]
+#  When specified it allows for customization
+#  of pam_sss.so in password type
+#  *Requires* pam_sss => true
+#  *Optional* defaults to 'sufficient    pam_sss.so use_authtok'
+#
+#  [pam_sss_session]
+#  When specified it allows for customization
+#  of pam_sss.so in session type
+#  *Requires* pam_sss => true
+#  *Optional* defaults to 'optional      pam_sss.so'
+#
 #  [pam_tally]
 #  UNTESTED
 #  *Optional* defaults to false
@@ -179,6 +207,12 @@ class pam::pamd (
   $pam_ldapd_password    = false,
   $pam_ldapd_session     = false,
 
+  $pam_sss               = false,
+  $pam_sss_account       = false,
+  $pam_sss_auth          = false,
+  $pam_sss_password      = false,
+  $pam_sss_session       = false,
+
   $pam_tally             = false,
   $pam_tally_account     = false,
   $pam_tally_auth        = false,
@@ -273,6 +307,40 @@ class pam::pamd (
     case $pam_ldapd_session {
       false:   { $pam_ldapd_session_set = $pam::params::pam_ldapd_session }
       default: { $pam_ldapd_session_set = $pam_ldapd_session }
+    }
+
+  }
+
+  if($pam_sss) {
+
+    package { 'sssd':
+      ensure => present,
+    }
+
+    service { 'sssd':
+      ensure => running,
+      enabled => true,
+      require => Package['sssd'],
+    }
+
+    case $pam_sss_account {
+      false:   { $pam_sss_account_set = $pam::params::pam_sss_account }
+      default: { $pam_sss_account_set = $pam_sss_account }
+    }
+
+    case $pam_sss_auth {
+      false:   { $pam_sss_auth_set = $pam::params::pam_sss_auth }
+      default: { $pam_sss_auth_set = $pam_sss_auth }
+    }
+
+    case $pam_sss_password {
+      false:   { $pam_sss_password_set = $pam::params::pam_sss_password }
+      default: { $pam_sss_password_set = $pam_sss_password }
+    }
+
+    case $pam_sss_session {
+      false:   { $pam_sss_session_set = $pam::params::pam_sss_session }
+      default: { $pam_sss_session_set = $pam_sss_session }
     }
 
   }

--- a/manifests/pamd/redhat.pp
+++ b/manifests/pamd/redhat.pp
@@ -17,7 +17,7 @@ class pam::pamd::redhat {
 
   file { "${pam::params::prefix_pamd}/system-auth":
     ensure => link,
-    target => "${pam::params::prefix_pamd}/system-auth-ac",
+    target => 'system-auth-ac',
   }
 
   if($pam::pamd::pam_ldap) {

--- a/manifests/pamd/redhat.pp
+++ b/manifests/pamd/redhat.pp
@@ -16,7 +16,8 @@ class pam::pamd::redhat {
   }
 
   file { "${pam::params::prefix_pamd}/system-auth":
-    content => template('pam/pam.d/system-auth-ac.erb')
+    ensure => link,
+    target => "${pam::params::prefix_pamd}/system-auth-ac",
   }
 
   if($pam::pamd::pam_ldap) {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -88,7 +88,7 @@ class pam::params {
 
       $pam_cracklib_password = 'requisite     pam_cracklib.so try_first_pass retry=3 minlen=9 dcredit=-1'
 
-      $pam_mkhomedir_session = "requisite     ${pam_mkhomedir_so} skel=/etc/skel/ umask=0022"
+      $pam_mkhomedir_session = "optional      ${pam_mkhomedir_so} skel=/etc/skel umask=0022"
 
     }
 
@@ -119,7 +119,7 @@ class pam::params {
 
       $pam_cracklib_password = 'requisite     pam_cracklib.so try_first_pass retry=3 minlen=9 dcredit=-1'
 
-      $pam_mkhomedir_session = 'requisite     pam_mkhomedir.so skel=/etc/skel/ umask=0022'
+      $pam_mkhomedir_session = 'optional      pam_mkhomedir.so skel=/etc/skel umask=0022'
 
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,12 +44,12 @@ class pam::params {
       case $::operatingsystemmajrelease {
         5 : {
           $package_pam_ldap = 'nss_ldap'
-          $pam_mkhomedir_so = 'pam_mkhomdir.so'
+          $pam_mkhomedir_so = 'pam_mkhomedir.so'
         }
 
         6 : {
           $package_pam_ldap = 'nss-pam-ldapd'
-          $pam_mkhomedir_so = 'pam_oddjob_mkhomdir.so'
+          $pam_mkhomedir_so = 'pam_oddjob_mkhomedir.so'
           $pam_mkhomedir_package = 'oddjob-mkhomedir'
         }
       

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,7 +31,7 @@ class pam::params {
 
       $pam_cracklib_password = 'requisite     pam_cracklib.so try_first_pass retry=3 minlen=9 dcredit=-1'
 
-      $pam_mkhomedir_session = 'requisite     pam_mkhomedir.so skel=/etc/skel/ umask=0022'
+      $pam_mkhomedir_session = 'optional      pam_mkhomedir.so skel=/etc/skel/ umask=0022'
 
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,7 +31,7 @@ class pam::params {
 
       $pam_cracklib_password = 'requisite     pam_cracklib.so try_first_pass retry=3 minlen=9 dcredit=-1'
 
-      $pam_mkhomedir_session = 'optional      pam_mkhomedir.so skel=/etc/skel/ umask=0022'
+      $pam_mkhomedir_session = 'optional      pam_mkhomedir.so skel=/etc/skel umask=0022'
 
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -70,6 +70,11 @@ class pam::params {
       $pam_ldapd_password    = false
       $pam_ldapd_session     = false
 
+      $pam_sss_account       = '[default=bad success=ok user_unknown=ignore] pam_sss.so'
+      $pam_sss_auth          = 'sufficient    pam_sss.so use_first_pass'
+      $pam_sss_password      = 'sufficient    pam_sss.so use_authtok'
+      $pam_sss_session       = 'optional      pam_sss.so'
+
       $ldap_conf             = '/etc/openldap/ldap.conf'
 
       $pam_tally_account     = 'required      pam_tally.so'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -55,6 +55,11 @@ class pam::params {
         }
       }
 
+      $pam_unix_account      = 'required      pam_unix.so broken_shadow'
+      $pam_unix_auth         = 'sufficient    pam_unix.so nullok try_first_pass'
+      $pam_unix_password     = 'sufficient    pam_unix.so md5 shadow nullok try_first_pass use_authtok'
+      $pam_unix_session      = 'required      pam_unix.so'
+
       $pam_ldap_account      = '[default=bad success=ok user_unknown=ignore] pam_ldap.so'
       $pam_ldap_auth         = 'sufficient    pam_ldap.so use_first_pass'
       $pam_ldap_password     = 'sufficient    pam_ldap.so use_authtok'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,10 +44,13 @@ class pam::params {
       case $::operatingsystemmajrelease {
         5 : {
           $package_pam_ldap = 'nss_ldap'
+          $pam_mkhomedir_so = 'pam_mkhomdir.so'
         }
 
         6 : {
           $package_pam_ldap = 'nss-pam-ldapd'
+          $pam_mkhomedir_so = 'pam_oddjob_mkhomdir.so'
+          $pam_mkhomedir_package = 'oddjob-mkhomedir'
         }
       
         default : {
@@ -85,7 +88,7 @@ class pam::params {
 
       $pam_cracklib_password = 'requisite     pam_cracklib.so try_first_pass retry=3 minlen=9 dcredit=-1'
 
-      $pam_mkhomedir_session = 'requisite     pam_mkhomedir.so skel=/etc/skel/ umask=0022'
+      $pam_mkhomedir_session = "requisite     ${pam_mkhomedir_so} skel=/etc/skel/ umask=0022"
 
     }
 

--- a/templates/pam.d/system-auth-ac.erb
+++ b/templates/pam.d/system-auth-ac.erb
@@ -49,7 +49,7 @@ password    required      pam_deny.so
 session     optional      pam_keyinit.so revoke
 session     required      pam_limits.so
 <% if scope.lookupvar('pam::pamd::pam_mkhomedir') == true then -%>
-session     <%= scope.lookupvar('pam::pamd::pam_mkhomdir_session_set') %>
+session     <%= scope.lookupvar('pam::pamd::pam_mkhomedir_session_set') %>
 <% end -%>
 session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid
 session     <%= scope.lookupvar('pam::pamd::pam_unix_session_set') %>

--- a/templates/pam.d/system-auth-ac.erb
+++ b/templates/pam.d/system-auth-ac.erb
@@ -10,7 +10,7 @@ auth        <%= scope.lookupvar('pam::pamd::pam_tally_auth_set') %>
 auth        <%= scope.lookupvar('pam::pamd::pam_tally2_auth_set') %>
 <% end -%>
 auth        required      pam_env.so
-auth        sufficient    pam_unix.so nullok try_first_pass
+auth        <%= scope.lookupvar('pam::pamd::pam_unix_auth_set') %>
 auth        requisite     pam_succeed_if.so uid >= 500 quiet
 <% if scope.lookupvar('pam::pamd::pam_ldap') == true then -%>
 auth        <%= scope.lookupvar('pam::pamd::pam_ldap_auth_set') %>
@@ -23,15 +23,15 @@ account	    <%= scope.lookupvar('pam::pamd::pam_tally_account_set') %>
 <% if scope.lookupvar('pam::pamd::pam_tally2') == true then -%>
 account	    <%= scope.lookupvar('pam::pamd::pam_tally2_account_set') %>
 <% end -%>
-account     required      pam_unix.so broken_shadow
+account     <%= scope.lookupvar('pam::pamd::pam_unix_account_set') %>
 account     sufficient    pam_succeed_if.so uid < 500 quiet
 <% if scope.lookupvar('pam::pamd::pam_ldap') == true then -%>
-account	    <%= scope.lookupvar('pam::pamd::pam_ldap_account_set') %>
+account     <%= scope.lookupvar('pam::pamd::pam_ldap_account_set') %>
 <% end -%>
 account     required      pam_permit.so
 
 password    requisite     pam_cracklib.so try_first_pass retry=3 type=
-password    sufficient    pam_unix.so md5 shadow nullok try_first_pass use_authtok
+password    <%= scope.lookupvar('pam::pamd::pam_unix_password_set') %>
 <% if scope.lookupvar('pam::pamd::pam_ldap') == true then -%>
 password    <%= scope.lookupvar('pam::pamd::pam_ldap_password_set') %>
 <% end -%>
@@ -40,7 +40,7 @@ password    required      pam_deny.so
 session     optional      pam_keyinit.so revoke
 session     required      pam_limits.so
 session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid
-session     required      pam_unix.so
+session     <%= scope.lookupvar('pam::pamd::pam_unix_session_set') %>
 <% if scope.lookupvar('pam::pamd::pam_ldap') == true then -%>
-session	    <%= scope.lookupvar('pam::pamd::pam_ldap_session_set') %>
+session     <%= scope.lookupvar('pam::pamd::pam_ldap_session_set') %>
 <% end -%>

--- a/templates/pam.d/system-auth-ac.erb
+++ b/templates/pam.d/system-auth-ac.erb
@@ -27,6 +27,7 @@ account	    <%= scope.lookupvar('pam::pamd::pam_tally_account_set') %>
 account	    <%= scope.lookupvar('pam::pamd::pam_tally2_account_set') %>
 <% end -%>
 account     <%= scope.lookupvar('pam::pamd::pam_unix_account_set') %>
+account     sufficient    pam_localuser.so
 account     sufficient    pam_succeed_if.so uid < 500 quiet
 <% if scope.lookupvar('pam::pamd::pam_sss') == true then -%>
 account     <%= scope.lookupvar('pam::pamd::pam_sss_account_set') %>

--- a/templates/pam.d/system-auth-ac.erb
+++ b/templates/pam.d/system-auth-ac.erb
@@ -48,6 +48,9 @@ password    required      pam_deny.so
 
 session     optional      pam_keyinit.so revoke
 session     required      pam_limits.so
+<% if scope.lookupvar('pam::pamd::pam_mkhomedir') == true then -%>
+session     <%= scope.lookupvar('pam::pamd::pam_mkhomdir_session_set') %>
+<% end -%>
 session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid
 session     <%= scope.lookupvar('pam::pamd::pam_unix_session_set') %>
 <% if scope.lookupvar('pam::pamd::pam_sss') == true then -%>

--- a/templates/pam.d/system-auth-ac.erb
+++ b/templates/pam.d/system-auth-ac.erb
@@ -12,6 +12,9 @@ auth        <%= scope.lookupvar('pam::pamd::pam_tally2_auth_set') %>
 auth        required      pam_env.so
 auth        <%= scope.lookupvar('pam::pamd::pam_unix_auth_set') %>
 auth        requisite     pam_succeed_if.so uid >= 500 quiet
+<% if scope.lookupvar('pam::pamd::pam_sss') == true then -%>
+auth        <%= scope.lookupvar('pam::pamd::pam_sss_auth_set') %>
+<% end -%>
 <% if scope.lookupvar('pam::pamd::pam_ldap') == true then -%>
 auth        <%= scope.lookupvar('pam::pamd::pam_ldap_auth_set') %>
 <% end -%>
@@ -25,6 +28,9 @@ account	    <%= scope.lookupvar('pam::pamd::pam_tally2_account_set') %>
 <% end -%>
 account     <%= scope.lookupvar('pam::pamd::pam_unix_account_set') %>
 account     sufficient    pam_succeed_if.so uid < 500 quiet
+<% if scope.lookupvar('pam::pamd::pam_sss') == true then -%>
+account     <%= scope.lookupvar('pam::pamd::pam_sss_account_set') %>
+<% end -%>
 <% if scope.lookupvar('pam::pamd::pam_ldap') == true then -%>
 account     <%= scope.lookupvar('pam::pamd::pam_ldap_account_set') %>
 <% end -%>
@@ -32,6 +38,9 @@ account     required      pam_permit.so
 
 password    requisite     pam_cracklib.so try_first_pass retry=3 type=
 password    <%= scope.lookupvar('pam::pamd::pam_unix_password_set') %>
+<% if scope.lookupvar('pam::pamd::pam_sss') == true then -%>
+password    <%= scope.lookupvar('pam::pamd::pam_sss_password_set') %>
+<% end -%>
 <% if scope.lookupvar('pam::pamd::pam_ldap') == true then -%>
 password    <%= scope.lookupvar('pam::pamd::pam_ldap_password_set') %>
 <% end -%>
@@ -41,6 +50,9 @@ session     optional      pam_keyinit.so revoke
 session     required      pam_limits.so
 session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid
 session     <%= scope.lookupvar('pam::pamd::pam_unix_session_set') %>
+<% if scope.lookupvar('pam::pamd::pam_sss') == true then -%>
+session     <%= scope.lookupvar('pam::pamd::pam_sss_session_set') %>
+<% end -%>
 <% if scope.lookupvar('pam::pamd::pam_ldap') == true then -%>
 session     <%= scope.lookupvar('pam::pamd::pam_ldap_session_set') %>
 <% end -%>

--- a/templates/pam.d/system-auth-ac.erb
+++ b/templates/pam.d/system-auth-ac.erb
@@ -1,39 +1,39 @@
 ###############################################################################
 # << FILE MANAGED BY PUPPET >>
-# Manual changes are likey to be overwritten
+# Manual changes are likely to be overwritten
 ###############################################################################
 
 <% if scope.lookupvar('pam::pamd::pam_tally') == true then -%>
-auth  <%= scope.lookupvar('pam::pamd::pam_tally_auth_set') %>
+auth        <%= scope.lookupvar('pam::pamd::pam_tally_auth_set') %>
 <% end -%>
 <% if scope.lookupvar('pam::pamd::pam_tally2') == true then -%>
-auth  <%= scope.lookupvar('pam::pamd::pam_tally2_auth_set') %>
+auth        <%= scope.lookupvar('pam::pamd::pam_tally2_auth_set') %>
 <% end -%>
 auth        required      pam_env.so
 auth        sufficient    pam_unix.so nullok try_first_pass
 auth        requisite     pam_succeed_if.so uid >= 500 quiet
 <% if scope.lookupvar('pam::pamd::pam_ldap') == true then -%>
-auth  <%= scope.lookupvar('pam::pamd::pam_ldap_auth_set') %>
+auth        <%= scope.lookupvar('pam::pamd::pam_ldap_auth_set') %>
 <% end -%>
 auth        required      pam_deny.so
 
 <% if scope.lookupvar('pam::pamd::pam_tally') == true then -%>
-account	<%= scope.lookupvar('pam::pamd::pam_tally_account_set') %>
+account	    <%= scope.lookupvar('pam::pamd::pam_tally_account_set') %>
 <% end -%>
 <% if scope.lookupvar('pam::pamd::pam_tally2') == true then -%>
-account	<%= scope.lookupvar('pam::pamd::pam_tally2_account_set') %>
+account	    <%= scope.lookupvar('pam::pamd::pam_tally2_account_set') %>
 <% end -%>
 account     required      pam_unix.so broken_shadow
 account     sufficient    pam_succeed_if.so uid < 500 quiet
 <% if scope.lookupvar('pam::pamd::pam_ldap') == true then -%>
-account	<%= scope.lookupvar('pam::pamd::pam_ldap_account_set') %>
+account	    <%= scope.lookupvar('pam::pamd::pam_ldap_account_set') %>
 <% end -%>
 account     required      pam_permit.so
 
 password    requisite     pam_cracklib.so try_first_pass retry=3 type=
 password    sufficient    pam_unix.so md5 shadow nullok try_first_pass use_authtok
 <% if scope.lookupvar('pam::pamd::pam_ldap') == true then -%>
-password  <%= scope.lookupvar('pam::pamd::pam_ldap_password_set') %>
+password    <%= scope.lookupvar('pam::pamd::pam_ldap_password_set') %>
 <% end -%>
 password    required      pam_deny.so
 
@@ -42,6 +42,5 @@ session     required      pam_limits.so
 session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid
 session     required      pam_unix.so
 <% if scope.lookupvar('pam::pamd::pam_ldap') == true then -%>
-session	<%= scope.lookupvar('pam::pamd::pam_ldap_session_set') %>
+session	    <%= scope.lookupvar('pam::pamd::pam_ldap_session_set') %>
 <% end -%>
-


### PR DESCRIPTION
Sorry for this being such a large pull request. For RHEL, they recommend the use of [sssd](https://fedorahosted.org/sssd/) to cache security creds to limit load on your ldap server so I have added this functionality since we needed it. On top of that, we use sha512 instead of md5 in our pam_unix configuration so I added the ability to customize this the same way you have the others. The default is still md5 though. Let me know if you have any further questions or requests. Thanks.
